### PR TITLE
Events

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The following table contains the events emitted by TCP Emitter server
 Name        | Description
 ----------- | -----------
 `subscribe`   | Event emitted when a `TCP Emitter client` subscribes to a TCP Emitter event. The listeners of this event are invoked with the `TCP Emitter client` & `event name`. Note when a `TCP Emitter client` requests to subscribe to an event that it is already subscribed to, this event is not emitted.
-`unsubscribe` | Event emitted when a `TCP Emitter client` unsubscribes to a TCP Emitter event. The listeners of this event are invoked with the TCP Emitter client & event name. Note when a `TCP Emitter client` requests to unsubscribe from an event that it is not subscribed to, this event is not emitted.
+`unsubscribe` | Event emitted when a `TCP Emitter client` unsubscribes to a TCP Emitter event. The listeners of this event are invoked with the `TCP Emitter client` & `event name`. Note when a `TCP Emitter client` requests to unsubscribe from an event that it is not subscribed to, this event is not emitted.
 `broadcast`   | Event emitted when a `TCP Emitter client` broadcasts to a TCP Emitter event. The listeners of this event are invoked with the `TCP Emitter client`, `event name` & `broadcast arguments`.
 
 # TCP Emitter Clients

--- a/README.md
+++ b/README.md
@@ -51,6 +51,16 @@ const verifyClient = socket => {
 require('tcpEmitter')(verifyClient).listen({ host: 'localhost', port: 8080 })
 ```
 
+# Events
+
+The following table contains the events emitted by TCP Emitter server
+
+Name        | Description
+----------- | -----------
+`subscribe`   | Event emitted when a `TCP Emitter client` subscribes to a TCP Emitter event. The listeners of this event are invoked with the `TCP Emitter client` & `event name`. Note when a `TCP Emitter client` requests to subscribe to an event that it is already subscribed to, this event is not emitted.
+`unsubscribe` | Event emitted when a `TCP Emitter client` unsubscribes to a TCP Emitter event. The listeners of this event are invoked with the TCP Emitter client & event name. Note when a `TCP Emitter client` requests to unsubscribe from an event that it is not subscribed to, this event is not emitted.
+`broadcast`   | Event emitted when a `TCP Emitter client` broadcasts to a TCP Emitter event. The listeners of this event are invoked with the `TCP Emitter client`, `event name` & `broadcast arguments`.
+
 # TCP Emitter Clients
 As specified in the introduction, these can be implemented in any language as long as they follow the TCP Emitter Payload spec. A TCP Emitter client can do the following three different interactions with the `TCP Emitter server`:
 

--- a/src/client.js
+++ b/src/client.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const utils = require('./utils')
+const eventList = require('./event-list')
 
 /**
  * @module tcp-emitter-client
@@ -12,13 +13,6 @@ module.exports = {
    * @type {module:tcp-emitter.delimiter}
    */
   delimiter: null,
-
-  /**
-   * Name of the event emitted by TCP Emitter clients upon the receival of a
-   * valid payload.
-   * @type {string}
-   */
-  tcpEmitterPayloadEvent: null,
 
   /**
    * Stores the name of the events which the TCP Emitter client is subscribed
@@ -35,20 +29,13 @@ module.exports = {
    * @param  {string} opts.delimiter              Delimiter used to seperate
    *                                              payloads in a single TCP
    *                                              request
-   * @param  {string} opts.tcpEmitterPayloadEvent Name of the event emitted
-   *                                              by TCP Emitter clients upon
-   *                                              the receival of a valid
-   *                                              payload.
    */
-  init ({ delimiter, tcpEmitterPayloadEvent }) {
+  init ({ delimiter }) {
     // Setup subscriptions list.
     this.subscriptions = []
 
     // Setup delimiter.
     this.delimiter = delimiter
-
-    // Setup event name used to emit valid TCP Emitter payloads.
-    this.tcpEmitterPayloadEvent = tcpEmitterPayloadEvent
 
     // Setup default encoding.
     this.setEncoding('utf-8')
@@ -91,7 +78,7 @@ module.exports = {
       if (isTypeValid !== false || isEventValid !== false) return
 
       // Emit payload to TCP Emitter Payload event if found valid.
-      this.emit(this.tcpEmitterPayloadEvent, payload)
+      this.emit(eventList.payload, payload)
     })
   }
 }

--- a/src/client.js
+++ b/src/client.js
@@ -31,7 +31,7 @@ module.exports = {
 
   /**
    * Function used to initialize a TCP Emitter client.
-   * @param  {string} opts                        Options for init function.
+   * @param  {Object} opts                        Options for init function.
    * @param  {string} opts.delimiter              Delimiter used to seperate
    *                                              payloads in a single TCP
    *                                              request

--- a/src/event-list.js
+++ b/src/event-list.js
@@ -1,0 +1,36 @@
+'use strict'
+
+/**
+ * Enum for the event names emitted by this module.
+ * @readonly
+ * @enum {string}
+ */
+module.exports = {
+  /**
+   * Event emitted by TCP Emitter client when it receives and parses a valid
+   * TCP Emitter payload
+   * @type {string}
+   */
+  payload: 'tcp-emitter-payload',
+
+  /**
+   * Event emitted by TCP Emitter server when a TCP Emitter client subscribes to
+   * an event.
+   * @type {string}
+   */
+  subscribe: 'tcp-emitter-subscribe',
+
+  /**
+   * Event emitted by TCP Emitter server when a TCP Emitter client unsubscribes
+   * from an event.
+   * @type {string}
+   */
+  broadcast: 'tcp-emitter-broadcast',
+
+  /**
+   * Event emitted by TCP Emitter server when a TCP Emitter client broadcasts to
+   * an event.
+   * @type {string}
+   */
+  unsubscribe: 'tcp-emitter-unsubscribe'
+}

--- a/src/index.js
+++ b/src/index.js
@@ -44,6 +44,7 @@ module.exports = function createTCPEmitterServer (opts = {}) {
 
   // Expose events that can be used by the TCP Emitter server user.
   ;[
+    'error',
     eventList.subscribe,
     eventList.broadcast,
     eventList.unsubscribe

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,8 @@
 'use strict'
 
 const net = require('net')
+const EventEmitter = require('events')
+const eventList = require('./event-list')
 const tcpEmitter = require('./tcp-emitter')
 
 /**
@@ -28,14 +30,25 @@ module.exports = function createTCPEmitterServer (opts = {}) {
    * TCP Emitter object.
    * @type {module:tcp-emitter}
    */
-  const tcpEmitterInst = Object.create(tcpEmitter)
+  const tcpEmitterInst = Object.assign(Object.create(new EventEmitter()),
+    tcpEmitter)
 
   // Initialize the newly created TCP Emitter.
   tcpEmitterInst.init({ delimiter: opts.delimiter })
 
   // Create & return a new TCP Server configured such that new connections are
   // handled by TCP Emitter.
-  return net.createServer(tcpEmitterInst.handleSocket({
+  const server = net.createServer(tcpEmitterInst.handleSocket({
     verifyClient: opts.verifyClient
   }))
+
+  // Expose events that can be used by the TCP Emitter server user.
+  ;[
+    eventList.subscribe,
+    eventList.broadcast,
+    eventList.unsubscribe
+  ].forEach(ev => tcpEmitterInst.on(ev, (...args) => server.emit(ev, ...args)))
+
+  // Return the TCP server.
+  return server
 }

--- a/src/tcp-emitter.js
+++ b/src/tcp-emitter.js
@@ -210,9 +210,6 @@ module.exports = {
     // Stop process if the specified event has no listeners.
     if (listeners === undefined) return
 
-    // Next we will be removing the TCP Emitter client from the event's list of
-    // listeners.
-
     /**
      * The position of the TCP Emitter client inside the event's list of
      * listeners.
@@ -228,7 +225,12 @@ module.exports = {
     listeners.splice(socketPosition, 1)
 
     // Remove the event's entry if it doesn't have any listeners left.
-    if (listeners.length === 0) return delete this.subscriptions[event]
+    if (listeners.length === 0) delete this.subscriptions[event]
+
+    // Emit TCP Emitter Unsubscribe Event with:
+    //   * the TCP Emitter client.
+    //   * name of the event.
+    this.emit(eventList.unsubscribe, socket, event)
   },
 
   /**

--- a/src/tcp-emitter.js
+++ b/src/tcp-emitter.js
@@ -146,7 +146,7 @@ module.exports = {
    * Function used to subscribe a TCP Emitter client to an event.
    * @see {@link https://nodejs.org/api/net.html#net_class_net_socket|
    *      net.Socket}
-   * @param  {net.Socket} opts        Options for subscribe function.
+   * @param  {Object} opts            Options for subscribe function.
    * @param  {net.Socket} opts.socket TCP Emitter client to be subscribed.
    * @param  {stirng}     opts.event  Event name which the TCP Emitter client
    *                                  will be subscribing to.
@@ -176,7 +176,7 @@ module.exports = {
    * Function used to unsubscribe a TCP Emitter client from an event.
    * @see {@link https://nodejs.org/api/net.html#net_class_net_socket|
    *      net.Socket}
-   * @param  {net.Socket} opts        Options for unsubscribe function.
+   * @param  {Object} opts            Options for unsubscribe function.
    * @param  {net.Socket} opts.socket TCP Emitter client to be unsubscribed.
    * @param  {string} opts.event      Event name which the TCP Emitter client
    *                                  will be unsubscribed from.
@@ -234,7 +234,7 @@ module.exports = {
    * which itself is subscribed to, it won't be notified.
    * @see {@link https://nodejs.org/api/net.html#net_class_net_socket|
    *      net.Socket}
-   * @param  {net.Socket} opts        Options for broadcast function.
+   * @param  {Object} opts            Options for broadcast function.
    * @param  {net.Socket} opts.socket TCP Emitter client broadcasting the
    *                                  payload.
    * @param  {string} opts.event      Event which the payload will be

--- a/src/tcp-emitter.js
+++ b/src/tcp-emitter.js
@@ -1,13 +1,7 @@
 'use strict'
 
+const eventList = require('./event-list')
 const tcpEmitterClient = require('./client')
-
-/**
- * Name of the event emitted by TCP Emitter clients upon the receival of a valid
- * payload.
- * @type {string}
- */
-const TCP_EMITTER_PAYLOAD_EVENT = 'tcp-emitter-payload'
 
 /**
  * @module tcp-emitter
@@ -88,13 +82,12 @@ module.exports = {
 
     // Initialize the newly created TCP Emitter client.
     tcpEmitterClientInst.init({
-      delimiter: this.delimiter,
-      tcpEmitterPayloadEvent: TCP_EMITTER_PAYLOAD_EVENT
+      delimiter: this.delimiter
     })
 
     // Listen for & parse new TCP Emitter payloads sent by the TCP Emitter
     // client.
-    tcpEmitterClientInst.on(TCP_EMITTER_PAYLOAD_EVENT, payload => {
+    tcpEmitterClientInst.on(eventList.payload, payload => {
       this.parsePayload({ payload, socket: tcpEmitterClientInst })
     })
 

--- a/src/tcp-emitter.js
+++ b/src/tcp-emitter.js
@@ -163,6 +163,10 @@ module.exports = {
 
     // Finally include the TCP Emitter client in the event's list of listeners.
     listeners.push(socket)
+
+    // Emit TCP Emitter Subscribe Event with the TCP Emitter client & name of
+    // the event.
+    this.emit(eventList.subscribe, socket, event)
   },
 
   /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -32,5 +32,33 @@ module.exports = {
     } catch (e) {
       return {}
     }
+  },
+
+  /**
+   * Function used to promisify the 'net.Socket.write' function.
+   * @see {@link https://nodejs.org/api/net.html#net_class_net_socket|
+   *      net.Socket}
+   * @param  {net.Socket} socket  TCP Emitter client that the message will be
+   *                              sent to.
+   * @param  {string} message     Message to be sent.
+   * @return {Promise}            When the message is sent successfully, it
+   *                              returns a resolved promise.
+   * @return {Promise.<Error>}    When the message is not sent successfully, it
+   *                              returns a promise rejected with an error.
+   */
+  write (socket, message) {
+    return new Promise((resolve, reject) => {
+      // When the 'error' event is emitted, it means that the message has not
+      // been sent, thus reject the promise with the error.
+      socket.on('error', reject)
+
+      // Try sending the message to the TCP Emitter client and if it succeeds,
+      // remove the error listener added in this promise and resolve the
+      // promise.
+      socket.write(message, () => {
+        socket.removeListener('error', reject)
+        resolve()
+      })
+    })
   }
 }

--- a/test/tcp-emitter-server-test.js
+++ b/test/tcp-emitter-server-test.js
@@ -60,9 +60,7 @@ describe('TCP Emitter Server Tests:', function () {
           // Create the TCP Emitter client and connect it with the TCP Emitter
           // server for this test.
           return netUtils.createTCPEmitterClient(serverInst.address())
-            .then(client => {
-              clientInst = client
-            })
+            .then(client => { clientInst = client })
         })
 
         afterEach(function () {
@@ -131,9 +129,7 @@ describe('TCP Emitter Server Tests:', function () {
           // Create the TCP Emitter client and connect it with the TCP Emitter
           // server for this test.
           return netUtils.createTCPEmitterClient(serverInst.address())
-            .then(client => {
-              clientInst = client
-            })
+            .then(client => { clientInst = client })
         })
 
         afterEach(function () {

--- a/test/tcp-emitter-server-test.js
+++ b/test/tcp-emitter-server-test.js
@@ -125,7 +125,7 @@ describe('TCP Emitter Server Tests:', function () {
           describe('when a TCP Emitter client broadcasts to an event:', function () {
             /**
              * Arguments that will be broadcasted.
-             * @type {Array.<any>}
+             * @type {Array.<*>}
              */
             let args = null
 
@@ -292,7 +292,7 @@ describe('TCP Emitter Server Tests:', function () {
             describe('when a TCP Emitter client broadcasts to an event:', function () {
               /**
                * Arguments that will be broadcasted.
-               * @type {Array.<any>}
+               * @type {Array.<*>}
                */
               let args = null
 
@@ -420,13 +420,13 @@ describe('TCP Emitter Server Tests:', function () {
           describe('when broadcasting multiple payloads with a single TCP request:', function () {
             /**
              * Arguments that will be broadcasted in the first payload.
-             * @type {Array.<any>}
+             * @type {Array.<*>}
              */
             let argsOne = null
 
             /**
              * Arguments that will be broadcasted in the second payload.
-             * @type {Array.<any>}
+             * @type {Array.<*>}
              */
             let argsTwo = null
 

--- a/test/tcp-emitter-server-test.js
+++ b/test/tcp-emitter-server-test.js
@@ -354,7 +354,7 @@ describe('TCP Emitter Server Tests:', function () {
        * TCP Emitter server.
        * @type {Object}
        */
-      var serverInst = null
+      let serverInst = null
 
       beforeEach(function () {
         // Create the TCP Emitter Server which the TCP Emitter clients will be

--- a/test/tcp-emitter-test.js
+++ b/test/tcp-emitter-test.js
@@ -2,6 +2,7 @@
 
 const net = require('net')
 const assert = require('assert')
+const EventEmitter = require('events')
 const { payload: payloadUtils } = require('./utils')
 const tcpEmitter = require('../src/tcp-emitter')
 
@@ -17,7 +18,8 @@ describe('TCP Emitter Tests:', function () {
       beforeEach(function () {
         // Create and initialize the TCP Emitter instance which the TCP Emitter
         // clients will be connecting to.
-        tcpEmitterInst = Object.create(tcpEmitter)
+        tcpEmitterInst = Object.assign(Object.create(new EventEmitter()),
+          tcpEmitter)
         tcpEmitterInst.init()
       })
 
@@ -114,7 +116,8 @@ describe('TCP Emitter Tests:', function () {
       beforeEach(function () {
         // Create and initialize the TCP Emitter instance which the TCP Emitter
         // clients will be connecting to.
-        tcpEmitterInst = Object.create(tcpEmitter)
+        tcpEmitterInst = Object.assign(Object.create(new EventEmitter()),
+          tcpEmitter)
         tcpEmitterInst.init()
       })
 

--- a/test/tcp-emitter-test.js
+++ b/test/tcp-emitter-test.js
@@ -116,7 +116,8 @@ describe('TCP Emitter Tests:', function () {
       beforeEach(function () {
         // Create and initialize the TCP Emitter instance which the TCP Emitter
         // clients will be connecting to.
-        tcpEmitterInst = Object.create(tcpEmitter)
+        tcpEmitterInst = Object.assign(Object.create(new EventEmitter()),
+          tcpEmitter)
         tcpEmitterInst.init()
       })
 

--- a/test/utils/payload.js
+++ b/test/utils/payload.js
@@ -35,7 +35,7 @@ module.exports = {
    * Function used to create the payload for broadcasting data to an event.
    * @param  {string} options.event      Event which the message will be
    *                                     broadcasted to.
-   * @param  {Array.<any>} options.args  Data to be broadcasted.
+   * @param  {Array.<*>} options.args  Data to be broadcasted.
    * @param  {string} options.delimiter  Delimiter used to seperate payloads in
    *                                     a single TCP request.
    * @return {string}                    Broadcasting payload of data to an


### PR DESCRIPTION
Enhance TCP Emitter server so that it emits the following events:

Name        | Description
----------- | -----------
`subscribe`   | Event emitted when a `TCP Emitter client` subscribes to a TCP Emitter event. The listeners of this event are invoked with the `TCP Emitter client` & `event name`. Note when a `TCP Emitter client` requests to subscribe to an event that it is already subscribed to, this event is not emitted.
`unsubscribe` | Event emitted when a `TCP Emitter client` unsubscribes to a TCP Emitter event. The listeners of this event are invoked with the `TCP Emitter client` & `event name`. Note when a `TCP Emitter client` requests to unsubscribe from an event that it is not subscribed to, this event is not emitted.
`broadcast`   | Event emitted when a `TCP Emitter client` broadcasts to a TCP Emitter event. The listeners of this event are invoked with the `TCP Emitter client`, `event name` & `broadcast arguments`.